### PR TITLE
🔥 Troubleshooting: Remove QkeleQ10's Troubleshooting

### DIFF
--- a/en/troubleshooting.md
+++ b/en/troubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshooting
 description: Everything to solve your problem
 published: true
-date: 2021-02-08T21:30:58.603Z
+date: 2021-06-17T16:18:21.153Z
 tags: 
 editor: markdown
 dateCreated: 2020-06-11T18:03:54.865Z
@@ -18,8 +18,6 @@ Included on this page:
 
 <a name="general"></a>
 # General troubleshooting
-> You can use [this](https://qkeleq10.github.io/PreMiD-Troubleshooting/) tool to more easily identify your issue.
-{.is-info}
 ### Reload the page
 You can press <kbd>CTRL+R</kbd>/<kbd>F5</kbd> (Windows) or <kbd>CMD+R</kbd> (MacOS) on your keyboard too instead of searching for the refresh button.
 


### PR DESCRIPTION
## Why this commit in first place?
From my perspective, while doing tickets, I don't see any help from this tool at all. This tool is not really great to identify issues since if we want to know __real__ issue, we need to ask them, not to use some troubleshooting page. Second, it is described as `tool to more easily identify your issue.`, well it is not and better option is to look at troubleshooting page because people don't really care and go straight to our support channel instead of searching answer in troubleshooting. Third, tool says: `It is acknowledged by but not owned by or affiliated with PreMiD`. It means that it shouldn't be in our docs since we don't affiliate it but it looks like we do from my perspective since it's in our docs. If our support agents see good thing in this tool, sure, then they can send it by themself since I have nothing towards this tool nor tool's author.
Edit: `I forgot to add that people sometimes even do tickets with result download Discord
like, it says on this site that they need to do it but they do it anyway
and this tool had to make find solutions better, not to make people sending ticket with it even when they know to download discord already when tool said it to them`

## What do I expect?
To merge this commit.

If you need more information why, please contact me @ discord.