### PR TITLE
docs: developer docs overhaul 

### DIFF
--- a/en/dev/api/v2.md
+++ b/en/dev/api/v2.md
@@ -11,78 +11,17 @@ dateCreated: 2021-09-07T01:44:43.430Z
 # v2
 
 > Base URL:
-https://api.premid.app/v2{.is-info}
-
+> https://api.premid.app/v2{.is-info}
 
 ## Endpoints
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left">Endpoint</th>
-      <th style="text-align:left">Type</th>
-      <th style="text-align:left">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align:left"><b>/betaAccess</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get the users who are able to access our beta program.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/changelog/:project/:version</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get our changelog.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/credits/:userID</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get Discord informations of our PreMiD Staff and Contributors / a specific user, using Discord User ID. Must be in our Discord server.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/langFile/list</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get all the available translated languages.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/langFile/:project/:lang</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get the translated strings of our website and extension.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/presences/:presence/:file</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get information about our Presences / a single Presence / a file of the presence (Ex: presence.js, metadata.json).</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/presenceUsage</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get the number of users from all of our presences.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/science</b>
-      </td>
-      <td style="text-align:left"><code>POST</code></td>
-      <td style="text-align:left">-</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/usage</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get the number of PreMiD users.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><b>/versions</b>
-      </td>
-      <td style="text-align:left"><code>GET</code></td>
-      <td style="text-align:left">Get the versions of our API, Application, Extension and Discord Bot.</td>
-    </tr>
-  </tbody>
-</table>
+
+| Name                           | Type  | Replacement                                     | Description                                                                                                                            |
+| ------------------------------ | ----- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| /betaAccess                    | `GET` | [alphaBetaAccess](./v3/queries#alphaBetaAccess) | Get the users who are able to access our beta program.                                                                                 |
+| `/changelog/:project/:version` | `GET` | [changelog](./v3/queries#changelog)             | Get our changelog.                                                                                                                     |
+| `/credits/:userID`             | `GET` | [credits](./v3/queries#credits)                 | Get Discord informations of our PreMiD Staff and Contributors / a specific user, using Discord User ID. Must be in our Discord server. |
+| `/langFile/`                   | `GET` | [langFiles](./v3/queries#langFiles)             | Get all the available translated languages.                                                                                            |
+| `/langFile/:project/:lang/`    | `GET` | [langFiles](./v3/queries#langFiles)             | Get all the available translated languages.                                                                                            |
+| /presences/:presence/:file     | `GET` | [presences](./v3/queries#presences)             | Get information about our Presences / a single Presence / a file of the presence (Ex: presence.js, metadata.json).                     |
+| /presenceUsage                 | `GET` | [usage](./v3/queries#usage)                     | Get the number of users from all of our presences.                                                                                     |
+| /versions                      | `GET` | [versions](./v3/queries#versions)               | Get the versions of our API, Application, Extension and Discord Bot.                                                                   |

--- a/en/dev/api/v3.md
+++ b/en/dev/api/v3.md
@@ -8,11 +8,12 @@ editor: markdown
 dateCreated: 2021-09-07T01:44:46.864Z
 ---
 
-# v3
+# V3 Reference Documentation
 
 > Base URL:
-https://api.premid.app/v3{.is-info}
+> https://api.premid.app/v3{.is-info}
 
-
-## Endpoints
-> Work in progress{.is-warning}
+[Mutations](./v3/mutations.md)
+[Objects](./v3/objects.md)
+[Queries](./v3/queries.md)
+[Scalars](./v3/scalars.md)

--- a/en/dev/api/v3/mutations.md
+++ b/en/dev/api/v3/mutations.md
@@ -1,0 +1,45 @@
+# Queries
+
+## addBetaUser
+
+Type: [AddBetaUserResult](./objects#AddBetaUserResult)
+
+Add a user to the beta
+
+### Arguments
+
+| Name                                  | Description         |
+| ------------------------------------- | ------------------- |
+| `token` ([String](./scalars#String)!) | Authorization token |
+
+---
+
+## addScience
+
+Type: [AddScienceResult](./objects#AddScienceResult)
+
+what does this do??????
+
+### Arguments
+
+| Name         | Type                                        | Description           |
+| ------------ | ------------------------------------------- | --------------------- |
+| `identifier` | (<code>[String](./scalars#String)!</code>)  |                       |
+| `identifier` | (<code>[String](./scalars#String)!</code>)  |                       |
+| `presences`  | (<code>[[String](./scalars#String)]</code>) | Presence to increment |
+| `os`         | (<code>[String](./scalars#String)</code>)   | Operating system      |
+| `arch`       | (<code>[String](./scalars#String)</code>)   |                       |
+
+---
+
+## deleteScience
+
+Type: [DeleteScienceResult](./objects#DeleteScienceResult)
+
+what does this do??????
+
+### Arguments
+
+| Name                                                    | Description |
+| ------------------------------------------------------- | ----------- |
+| `identifier` (<code>[String](./scalars#String)!</code>) |             |

--- a/en/dev/api/v3/objects.md
+++ b/en/dev/api/v3/objects.md
@@ -1,0 +1,308 @@
+# Objects
+
+## AlphaBetaAccess
+
+Whether the user has access to alpha or beta versions.
+
+### Fields
+
+| Name          | Type                          | Description                                       |
+| ------------- | ----------------------------- | ------------------------------------------------- |
+| `betaAccess`  | [Boolean](./scalars#Boolean)! | Whether the user has access to the beta versions  |
+| `alphaAccess` | [Boolean](./scalars#Boolean)! | Whether the user has access to the alpha versions |
+
+---
+
+## Benefit
+
+A benefit for working for PreMiD
+
+| Name          | Type                         | Description                |
+| ------------- | ---------------------------- | -------------------------- |
+| `description` | [String](./scalars#String)!  | Description of the benefit |
+| `icon`        | [String](./scalars#Boolean)! | Icon of the benefit        |
+| `title`       | [String](./scalars#Boolean)! | Title of the benefit       |
+
+---
+
+## BetaUsers
+
+Amount of users in PreMiD's beta program
+
+| Name                          | Description                         |
+| ----------------------------- | ----------------------------------- |
+| `number` [Int](./scalars#Int) | Amount of users on the beta program |
+
+---
+
+## Credits
+
+A contributor to the PreMiD project
+
+| Name          | Type                      | Description               |
+| ------------- | ------------------------- | ------------------------- |
+| `highestRole` | [Role](#Role)             | User's highest role       |
+| `roles`       | [[Role](#Role)]           | Array of the user's roles |
+| `user`        | [CreditUser](#CreditUser) |
+
+---
+
+## DiscordUser
+
+A Discord User
+
+| Name            | Type                       | Description                       |
+| --------------- | -------------------------- | --------------------------------- |
+| `avatar`        | [String](./scalars#String) |                                   |
+| `created`       | [Float](./scalars#Float)   | Users's account created timestamp |
+| `discriminator` | [String](./scalars#String) |                                   |
+| `userId`        | [String](./scalars#String) |                                   |
+| `username`      | [String](./scalars#String) |                                   |
+
+---
+
+## Presence
+
+A Presence
+
+| Name         | Type                                   | Description                          |
+| ------------ | -------------------------------------- | ------------------------------------ |
+| `iframeJs`   | [String](./scalars#String)             | Presence's iFrame.js file            |
+| `metadata`   | [PresenceMetadata](#PresenceMetadata)! | Presence's metadata                  |
+| `presenceJs` | [String](./scalars#String)!            | Presence's presence.js file          |
+| `url`        | [String](./scalars#String)!            | Presence's URL(s)                    |
+| `users`      | [Int](./scalars#Int)!                  | Amount of users who use the presence |
+
+---
+
+## Sponsor
+
+| Name          | Type                        | Description                |
+| ------------- | --------------------------- | -------------------------- |
+| `description` | [String](./scalars#String)! | Description of the sponsor |
+| `image`       | [String](./scalars#String)! | Logo of the sponsor        |
+| `name`        | [String](./scalars#String)! | Name of the sponsor        |
+| `tString`     | [String](./scalars#String)! |                            |
+
+---
+
+## Usage
+
+| Name    |                       | Description                           |
+| ------- | --------------------- | ------------------------------------- |
+| `count` | [Int](./scalars#Int)! | Amount of user's who use the presence |
+
+---
+
+## Versions
+
+| Name        | Type                               | Description                            |
+| ----------- | ---------------------------------- | -------------------------------------- |
+| `api`       | [String](./scalars#String)!        | Latest version of the API              |
+| `app`       | [String](./scalars#String)!        | Latest version of the application      |
+| `bot`       | [String](./scalars#String)!        | Latest version of the Discord Bot      |
+| `extension` | [String](./scalars#String)!        | Latest version of the extension        |
+| `linux`     | [String](./scalars#String)!        | Latest version of the Linux version    |
+| `safari`    | ([SafariVersion](#SafariVersion)!) | Latest version of the Safari extension |
+
+---
+
+## Partner
+
+A Partner
+
+| Name          | Type                        | Description                               |
+| ------------- | --------------------------- | ----------------------------------------- |
+| `description` | [String](./scalars#String)! | Description of the partner                |
+| `image`       | [String](./scalars#String)! | Logo of the partner                       |
+| `name`        | [String](./scalars#String)! | Name of the partner                       |
+| `storeName`   | [String](./scalars#String)! | Presence name associated with the partner |
+| `url`         | [String](./scalars#String)! | URL to the website of the parnter         |
+
+---
+
+## Download
+
+A download
+
+| Name          | Type                              | Description              |
+| ------------- | --------------------------------- | ------------------------ |
+| `appLinks`    | [[String](./scalars#String)]!     | Links to the application |
+| `enabled`     | [Boolean](./scalars#Float)!       |                          |
+| `extLinks`    | [[DownloadLink](#downloadLink)!]! | Links to the extension   |
+| `releaseType` | [String](./scalars#String)!       |                          |
+
+---
+
+## LangFile
+
+A language file
+
+| Name           | Type                       | Description               |
+| -------------- | -------------------------- | ------------------------- |
+| `lang`         | [String](./scalars#String) | Language's Locale         |
+| `presence`     | [String](./scalars#String) | **beep**                  |
+| `project`      | [String](./scalars#String) | **beep**                  |
+| `translations` | (JSON)                     | **FIX THE TYPE HEREEEEE** |
+
+---
+
+## Role
+
+A role
+
+| Name   | Type                       | Description      |
+| ------ | -------------------------- | ---------------- |
+| `id`   | [String](./scalars#String) | ID of the role   |
+| `name` | [String](./scalars#String) | Name of teh role |
+
+---
+
+## Job
+
+A job
+
+| Name           | Type                         | Description                              |
+| -------------- | ---------------------------- | ---------------------------------------- |
+| `available`    | [Boolean](./scalars#Boolean) | If the job is available or not           |
+| `bonusPoints`  | [[String](./scalars#String)] |                                          |
+| `jobName`      | [String](./scalars#String)   | Name of the job                          |
+| `jobIcon`      | [String](./scalars#String)   | Font awesome icon of the job             |
+| `questions`    | [JobQuestion](#JobQuestion)  | Questions for the application to the job |
+| `requirements` | [[String](./scalars#String)] | Requirements for the job                 |
+| `tasks`        | [[String](./scalars#String)] | Tasks fo the job                         |
+
+---
+
+## DownloadLink
+
+| Name       | Type                        | Description               |
+| ---------- | --------------------------- | ------------------------- |
+| `link`     | [String](./scalars#String)! | Link to the download      |
+| `platform` | [String](./scalars#String)! | Platform for the download |
+
+---
+
+## JobQuestion
+
+| Name       | Type                         | Description                 |
+| ---------- | ---------------------------- | --------------------------- |
+| `id`       | [String](./scalars#String)   | ID of the question          |
+| `question` | [String](./scalars#String)   | Question                    |
+| `required` | [Boolean](./scalars#Boolean) | If the response is required |
+
+---
+
+## PresenceMetaData
+
+| Name           | Type                                                   | Description                          |
+| -------------- | ------------------------------------------------------ | ------------------------------------ |
+| `altnames`     | [[String](./scalars#String)]                           | Presence alternative names           |
+| `author`       | [PresenceMetadataUser](#presenceMetadataUser)          | Presence author                      |
+| `button`       | [Boolean](./scalars#Boolean)                           |                                      |
+| `category`     | [String](./scalars#String)!                            | Presence category                    |
+| `color`        | [String](./scalars#String)!                            | Presence color                       |
+| `contributors` | [[PresenceMetadataUser](#presenceMetadataUser)]<code>) | Presence contributors                |
+| `description`  | (JSON)                                                 | **FIX THE TYPE HEREEEEE**            |
+| `iframe`       | [Boolean](./scalars#Boolean)                           | If the Presence has an iFrame or not |
+| `iframeRegExp` | [String](./scalars#String)                             |                                      |
+| `logo          | ` [String](./scalars#String)!                          | Presence logo                        |
+| `readLogs`     | [Boolean](./scalars#Boolean)                           |                                      |
+| `regExp`       | [String](./scalars#String)                             | Presence RegExp                      |
+| `service`      | [String](./scalars#String)!                            | Presence service name                |
+| `settings`     | [[String](#presenceMetadataSettings)!]                 | Presence settings                    |
+| `tags`         | [[String](./scalars#Strings)!]!                        | Presence tags                        |
+| `thumbnail`    | [String](./scalars#String)!                            | Presence thumbnail                   |
+| `url`          | ([Scalar](./scalars#Scalar)!)                          | **FIX THE TYPE HEREEEEE**            |
+| `versions`     | [String](./scalars#String)!                            | Presence version                     |
+| `warning`      | [Boolean](./scalars#String)                            |                                      |
+
+---
+
+## PresenceMetadataUser
+
+| Name   | Type                        | Description         |
+| ------ | --------------------------- | ------------------- |
+| `id`   | [String](./scalars#String)! | ID of the author    |
+| `name` | [String](./scalars#String)! | Name of the authour |
+
+---
+
+## PresenceMetadataSettings
+
+| Name            | Type                                                      | Description                        |
+| --------------- | --------------------------------------------------------- | ---------------------------------- |
+| `icon`          | [String](./scalars#String)                                | Font awesome icon for the presence |
+| `id`            | [String](./scalars#String)!                               |                                    |
+| `if`            | [PresenceMetadataSettingsIf](#presenceMetadataSettingsIf) |                                    |
+| `multiLanguage` | ([Scalar](./scalars#Scalars))                             | **FIX THE TYPE HEREEEEE**          |
+| `placeholder`   | [String](./scalars#String)                                | Place holder text                  |
+| `title`         | [String](./scalars#String)                                | Title of teh setting               |
+| `value`         | [String](./scalars#String)                                |                                    |
+| `values`        | [String](./scalars#String)                                |                                    |
+
+---
+
+## PresenceMetadataSettingsIf
+
+| Name               | Type                       | Description                |
+| ------------------ | -------------------------- | -------------------------- |
+| `patternProprties` | **FIX THE TYPE HEREEEEE**  | [Scalar](./scalars#Scalar) |
+| `propertyNames`    | [String](./scalars#String) |                            |
+
+---
+
+## SafariVersion
+
+| Name      | Type                         | Description                     |
+| --------- | ---------------------------- | ------------------------------- |
+| `urgent`  | [Boolean](./scalars#Boolean) |                                 |
+| `version` | [String](./scalars#String)   | Version of the Safari extension |
+
+---
+
+## AddBetaUserResult
+
+| Name      | Type                                             | Description                               |
+| --------- | ------------------------------------------------ | ----------------------------------------- |
+| `message` | [String](./scalars#String)!                      |                                           |
+| `success` | <code><code>[Boolean](./scalars#Boolean)</code>! | If the beta user was successfully created |
+
+---
+
+|
+
+## AddScienceResult
+
+| Name         | Type                         | Description |
+| ------------ | ---------------------------- | ----------- |
+| `arch`       | [String](./scalars#String)!  |             |
+| `identifier` | [String](./scalars#String)!  |             |
+| `os`         | [String](./scalars#String)!  |             |
+| `presences`  | [[String](./scalars#String)] |             |
+
+---
+
+## DeleteScienceResult
+
+| Name         | Type                        | Description |
+| ------------ | --------------------------- | ----------- |
+| `identifier` | [String](./scalars#String)! |
+
+## CreditUser
+
+| Name            | Type                         | Description                                                                                      |
+| --------------- | ---------------------------- | ------------------------------------------------------------------------------------------------ |
+| `avatar`        | [String](./scalars#String)   | User's avatar                                                                                    |
+| `flags`         | [[String](./scalars#String)] | User's [flags](https://discord.com/developers/docs/resources/user#user-object-user-flags)        |
+| `id`            | [String](./scalars#String)   | The user's                                                                                       |
+| `name`          | [String](./scalars#String)   | The username of the user                                                                         |
+| `premium_since` | [Float](./scalars#Float)     | Timestamp of when the user started boosting the guild                                            |
+| `role`          | [String](./scalars#String)   | An array of role ids                                                                             |
+| `roleColor`     | [String](./scalars#String)   | RGB color value                                                                                  |
+| `roleId`        | [String](./scalars#String)   | ID of a role                                                                                     |
+| `rolePosition`  | [Int](./scalars#Int)         | Position of the role                                                                             |
+| `status`        | [String](./scalars#String)   | a [status type](https://discord.com/developers/docs/topics/gateway#update-presence-status-types) |
+| `tag`           | [String](./scalars#String)   | integer representation of hexadecimal color code                                                 |
+
+---

--- a/en/dev/api/v3/queries.md
+++ b/en/dev/api/v3/queries.md
@@ -1,0 +1,164 @@
+# Queries
+
+## alphaBetaAccess
+
+Type: [AlphaBetaAccess](./objects#AlphaBetaAccess)
+
+Whether the user has access to alpha or beta versions.
+
+### Arguments
+
+| Name     | Type                                    | Description       |
+| -------- | --------------------------------------- | ----------------- |
+| `userId` | <code>[String](./scalars#String)</code> | User's Discord ID |
+
+---
+
+## benefits
+
+Returns the list of staff benefits
+
+Type: [[Benefits](./objects#Benefits)]
+
+## This query takes no arguments
+
+---
+
+## betaUsers
+
+Gives you the amount of users signed up for the PreMiD beta program
+
+Type: [BetaUsers](./objects#BetaUsers)
+
+This query takes no arguments
+
+---
+
+## credits
+
+Returns an object array of users who have contributed to the project
+
+Type: [Credits](./objects#Credits)
+
+| Name     | Type                                      | Description                                                           |
+| -------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| `id`     | <code>[String](./scalars#String)</code>   | User's Discord ID                                                     |
+| `limit`  | <code>[Int](./scalars#Int)</code>         | Maximum number of users to be returned, if the `id` param is provided |
+| `random` | <code>[Boolean](./scalars#Boolean)</code> | Fetches a random contibutor                                           |
+
+---
+
+## discordUsers
+
+Returns an array of users in the PreMiD guild
+
+Type: [DiscordUser](./objects#DiscordUser)
+
+| Name     | Type                                    | Description       |
+| -------- | --------------------------------------- | ----------------- |
+| `userId` | <code>[String](./scalars#String)</code> | User's Discord ID |
+
+---
+
+## downloads
+
+Returns an array of the downloads for PreMiD
+
+Type: [Download](./objects#Download)
+
+| Name          | Type                                    | Description                 |
+| ------------- | --------------------------------------- | --------------------------- |
+| `releaseType` | <code>[String](./scalars#String)</code> | Software release life cycle |
+| `token`       | <code>[String](./scalars#String)</code> |                             |
+
+---
+
+## langFiles
+
+Gives you
+
+Type: [LangFile](./objects#LangFile)
+
+| Name       | Type                                    | Description            |
+| ---------- | --------------------------------------- | ---------------------- |
+| `lang`     | <code>[String](./scalars#String)</code> | Locale of the language |
+| `project`  | <code>[String](./scalars#String)</code> |
+| `presence` | <code>[String](./scalars#String)</code> |
+
+---
+
+## partners
+
+Returns an array of PreMiD's Partners
+
+Type: [Partner](./objects#Partner)
+
+| Name   | Type                                    | Description         |
+| ------ | --------------------------------------- | ------------------- |
+| `name` | <code>[String](./scalars#String)</code> | Name of the Partner |
+
+---
+
+## presences
+
+Returns a Presence
+
+Type: [Presence](./objects#Presence)
+
+| Name          | Type                                    | Description                                |
+| ------------- | --------------------------------------- | ------------------------------------------ |
+| `service`     | <code>[String](./scalars#String)</code> | Name of the presence                       |
+| `author`      | <code>[String](./scalars#String)</code> | Author of the presence                     |
+| `contributor` | <code>[String](./scalars#String)</code> | Users who have contributed to the presence |
+| `start`       | <code>[Int](./scalars#Int)</code>       |                                            |
+| `limit`       | <code>[Int](./scalars#Int)</code>       |                                            |
+| `query`       | <code>[String](./scalars#String)</code> | Query to request a specific presence       |
+| `tag`         | <code>[String](./scalars#String)</code> | Tags for the presence                      |
+
+---
+
+## sponsors
+
+Returns array of the sponsors of PreMiD
+
+Type: [[Sponsor](./objects#Sponsor)]
+
+This query takes no arguments
+
+---
+
+## usage
+
+Returns an integer of the number of users for the given presence
+
+Type: [Usage](./objects#Usage)
+
+This query takes no arguments
+
+---
+
+## versions
+
+Returns the latest versions for the extension and application for each platform
+
+Type: [Versions](./objects#Versions)
+
+This query takes no arguments
+
+---
+
+## jobs
+
+Returns the vacant jobs
+
+Type: [Job](./objects#Job)
+
+This query takes no arguments
+
+---
+
+## changelog
+
+This query has been deprecated and no longer works{.is-danger}
+
+---

--- a/en/dev/api/v3/scalars.md
+++ b/en/dev/api/v3/scalars.md
@@ -1,0 +1,23 @@
+# Scalars
+
+## Boolean
+
+Represents `true` or `false` values.
+
+---
+
+## String
+
+Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text.
+
+---
+
+## Int
+
+Represents integer values. `Int` can represent values between -(2^31) and 2^31 - 1.
+
+---
+
+## Float
+
+Represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754).

--- a/en/dev/api/v4.md
+++ b/en/dev/api/v4.md
@@ -1,0 +1,19 @@
+---
+title: v4
+description:
+published: true
+date: 2021-12-20T14:27:18.034Z
+tags:
+editor: markdown
+dateCreated: 2021-09-07T01:44:46.864Z
+---
+
+# V3 Reference Documentation
+
+> Base URL:
+> https://api.premid.app/v3{.is-info}
+
+[Mutations](./v4/mutations.md)
+[Objects](./v4/objects.md)
+[Queries](./v4/queries.md)
+[Scalars](./v/scalars.md)

--- a/en/dev/api/v4/objects.md
+++ b/en/dev/api/v4/objects.md
@@ -1,0 +1,16 @@
+# Objects
+
+## AlphaBetaAccess
+
+Whether the user has access to alpha or beta versions.
+
+### Fields
+
+| Name           | Type                         | Description                          |
+| -------------- | ---------------------------- | ------------------------------------ |
+| `lang`         | [Boolean](./scalars#String)! | Locale code                          |
+| `project`      | [Boolean](./scalars#String)! | `extension`, `presence` or `website` |
+| `presence`     | [Boolean](./scalars#String)! | Presence                             |
+| `translations` | [Boolean](./scalars#Scalar)! | Strings in the language              |
+
+---

--- a/en/dev/api/v4/queries.md
+++ b/en/dev/api/v4/queries.md
@@ -1,0 +1,17 @@
+# Queries
+
+## strings
+
+Type: [AlphaBetaAccess](./objects#AlphaBetaAccess)
+
+Whether the user has access to alpha or beta versions.
+
+### Arguments
+
+| Name       | Type                                                 | Description                                         |
+| ---------- | ---------------------------------------------------- | --------------------------------------------------- |
+| `lang`     | <code>[String](./scalars#String)</code>              | Locale of the language                              |
+| `project`  | <code>[String](./scalars#String)</code>              | Possible values: 'extension', 'presence', 'website' |
+| `presence` | <code>[String](./scalars#StringOrStringArray)</code> | Presence                                            |
+
+---

--- a/en/dev/api/v4/scalars.md
+++ b/en/dev/api/v4/scalars.md
@@ -1,0 +1,31 @@
+# Scalars
+
+## Boolean
+
+Represents `true` or `false` values.
+
+---
+
+## String
+
+Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text.
+
+---
+
+## Int
+
+Represents integer values. `Int` can represent values between -(2^31) and 2^31 - 1.
+
+---
+
+## Float
+
+Represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754).
+
+---
+
+## StringOrStringArray
+
+String or array of strings.
+
+---

--- a/en/dev/presence.md
+++ b/en/dev/presence.md
@@ -9,15 +9,15 @@ dateCreated: 2020-06-11T18:04:02.843Z
 ---
 
 > All presences are now stored here: https://github.com/PreMiD/Presences
-{.is-info}
+> {.is-info}
 
 Version `2.x` introduces the [presence store](https://premid.app/store). Users now have the ability to manually add and remove their favourite presences through the user interface of the [website](https://premid.app/).
 
 > Before getting started, it is highly recommended that you look at our presence guidelines.
-{.is-warning}
+> {.is-warning}
 
 - [Guidelines](https://docs.premid.app/dev/presence/guidelines)
-{.links-list}
+  {.links-list}
 
 # Structure
 
@@ -275,13 +275,13 @@ Please copy the code above and put it in your `metadata.json` file. You now need
 
 ```ts
 const presence = new Presence({
-  //The client ID of the Application created at https://discordapp.com/developers/applications
-  clientId: "000000000000000000"
+    //The client ID of the Application created at https://discordapp.com/developers/applications
+    clientId: "000000000000000000",
   }),
   //You can use this to get translated strings in their browser language
   strings = presence.getStrings({
     play: "presence.playback.playing",
-    pause: "presence.playback.paused"
+    pause: "presence.playback.paused",
   });
 
 /*
@@ -309,14 +309,14 @@ presence.on("UpdateData", async () => {
     smallImageKey: "key",
     //The text which is displayed when hovering over the small image
     smallImageText: "Some hover text",
-     //The upper section of the presence text
+    //The upper section of the presence text
     details: "Browsing Page Name",
     //The lower section of the presence text
     state: "Reading section A",
     //The unix epoch timestamp for when to start counting from
     startTimestamp: 3133657200000,
     //If you want to show Time Left instead of Elapsed, this is the unix epoch timestamp at which the timer ends
-    endTimestamp: 3133700400000
+    endTimestamp: 3133700400000,
     //Optionally you can set a largeImageKey here and change the rest as variable subproperties, for example presenceData.type = "blahblah"; type examples: details, state, etc.
   };
   //Update the presence with all the values from the presenceData object
@@ -354,7 +354,7 @@ iframe.on("UpdateData", async () => {
   iframe.send({
     //sending data
     video: video,
-    time: video.duration
+    time: video.duration,
   });
 });
 ```

--- a/en/dev/presence/guidelines.md
+++ b/en/dev/presence/guidelines.md
@@ -252,7 +252,6 @@ Here is a list of rules you must follow when writing your `presence.ts` file:
   - They can't display information you couldn't fit in other fields.
   - Redirecting directly to audio/video stream is prohibited.
 
-
 ## [**tsconfig.json**](https://docs.premid.app/dev/presence/tsconfig)
 
 > Do **not** write your own `tsconfig.json` file, use what has been provided on [documentation](https://docs.premid.app/dev/presence/tsconfig).
@@ -311,7 +310,7 @@ A few things you should know after opening a pull request:
 
 Currently, a presence goes through 3 separate stages of checks. All of these checks help the reviewers determine whether your presence is suitable for deployment.
 
-- `DeepScan` is a bot that checks for code quality. If you ever receive errors for new issues, you are **required** to fix them. *Warning: DeepScan doesn't always give you errors. Please look at CodeFactor warnings instead.*
+- `DeepScan` is a bot that checks for code quality. If you ever receive errors for new issues, you are **required** to fix them. _Warning: DeepScan doesn't always give you errors. Please look at CodeFactor warnings instead._
 - `CodeFactor` is a bot that checks for code quality. If you ever receive errors for new issues, you are **required** to fix them.
 - `Schema Validation` will scan your `metadata.json` file for any errors (for e.g., missing fields, invalid value types, etc.). If you ever see any new issues, you are also **required** to fix those. Adding a schema field to your `metadata.json` file will allow your text editor (if supported) to show you these errors during development.
 


### PR DESCRIPTION
This pull request adds documentation for the `v3` and `v4` endpoints in their respective pages. 

I have purposefully not included: 
- `science` query as there is no point of indexing this.