### PR TITLE
fix(Presence): document getActivity as deprecated

### DIFF
--- a/en/dev/presence/class.md
+++ b/en/dev/presence/class.md
@@ -2,7 +2,7 @@
 title: Presence Class
 description: The main class for every PreMiD presence
 published: true
-date: 2021-12-20T14:27:18.034Z
+date: 2022-05-26T18:03:00.000Z
 tags:
 editor: markdown
 dateCreated: 2021-09-07T01:44:50.164Z
@@ -41,7 +41,7 @@ When setting `appMode` to `true` and the presence were to send an empty `Presenc
 
 ## Methods
 
-### `getActivity()`
+### `getActivity()` - *Deprecated since 2.2.4*
 
 Returns a `PresenceData` object of what the presence is displaying.
 


### PR DESCRIPTION
`Presence.getActivity` method is [deprecated](https://github.com/PreMiD/Presences/blob/fe97bd735ce31645e1a7260b1b1e1ae03ca78332/%40types/premid/index.d.ts#L282) and was not documented