### PR TITLE
Remove PreMiD-Troubleshooter link in troubleshooting.md

### DIFF
--- a/en/troubleshooting.md
+++ b/en/troubleshooting.md
@@ -18,8 +18,6 @@ Included on this page:
 
 <a name="general"></a>
 # General troubleshooting
-> You can use [this](https://qkeleq10.github.io/PreMiD-Troubleshooting/) tool to more easily identify your issue.
-{.is-info}
 ### Reload the page
 You can press <kbd>CTRL+R</kbd>/<kbd>F5</kbd> (Windows) or <kbd>CMD+R</kbd> (MacOS) on your keyboard too instead of searching for the refresh button.
 


### PR DESCRIPTION
The troubleshooter I created, which was linked here, was taken down on the request of PreMiD management. I keep receiving DMs on Discord because the troubleshooter does not work. Please have it removed.